### PR TITLE
[build] fix build script library destination

### DIFF
--- a/reuse-mlir/Cargo.toml
+++ b/reuse-mlir/Cargo.toml
@@ -7,4 +7,4 @@ build = "build.rs"
 [dependencies]
 
 [build-dependencies]
-cmake = "0.1.50"
+cmake = "0.1.51"

--- a/reuse-mlir/build.rs
+++ b/reuse-mlir/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let dst = cmake::Config::new(".").target("MLIRReuseIR").build();
+    let dst = cmake::Config::new(".").build().join("build").join("lib");
     println!("cargo:rustc-link-search=native={}", dst.display());
     println!("cargo:rustc-link-lib=MLIRReuseIR");
 }


### PR DESCRIPTION
The original build script would trigger many issues on macOS, it pops this error:

```plaintext
error occurred: Invalid target `MLIReuseIR`: no `-` in it
```

Which indicates that a target triple (e.g. `x86_64-apple-darwin`) is required in `.target("MLIRReuseIR")`, that is so unexpected and silly.

So I made these changes here and it worked, do they make sense in a general manner?