### PR TITLE
[ReuseIR] lowering most assemble operations

### DIFF
--- a/reuse-mlir/src/cxx/Interfaces/ReuseIRCompositeLayoutInterface.cpp
+++ b/reuse-mlir/src/cxx/Interfaces/ReuseIRCompositeLayoutInterface.cpp
@@ -28,6 +28,9 @@ CompositeLayout::CompositeLayout(mlir::DataLayout layout,
     llvm::TypeSize alignedSize = llvm::alignTo(size, typeAlign);
     if (alignedSize > size)
       raw_fields.emplace_back(alignedSize - size);
+    field_map.insert(
+        {fields.size(),
+         {raw_fields.size(), alignedSize, llvm::Align{typeAlign}}});
     raw_fields.emplace_back(unionBody->dataArea);
     size = alignedSize + typeSz;
   }


### PR DESCRIPTION
I am able to compile the list example to LLVM now!
```
./bin/reuse-opt ../reuse-mlir/test/integration/basic/list_of_i32.mlir -reuse-ir-closure-outlining -reuse-ir-token-reuse -reuse-ir-infer-union-tag -reuse-ir-expand-control-flow=outline-nested-release=0 -reuse-ir-acquire-release-fusion -reuse-ir-expand-control-flow=outline-nested-release=1 -convert-scf-to-cf -convert-arith-to-llvm -convert-reuse-ir-to-llvm -reconcile-unrealized-casts | mlir-translate-20 -mlir-to-llvmir | opt-20 -O3 -S
```

Somehow there is a quality issue:
```
; ModuleID = '<stdin>'
source_filename = "LLVMDialectModule"
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"

define ptr @reverse(ptr %0, ptr %1) local_unnamed_addr {
  br label %tailrecurse

tailrecurse:                                      ; preds = %43, %2
  %.tr = phi ptr [ %0, %2 ], [ %9, %43 ]
  %.tr78 = phi ptr [ %1, %2 ], [ %44, %43 ]
  %3 = getelementptr i8, ptr %.tr, i64 8
  %4 = load i1, ptr %3, align 1
  br i1 %4, label %46, label %5

5:                                                ; preds = %tailrecurse
  %6 = getelementptr i8, ptr %.tr, i64 16
  %7 = load i32, ptr %6, align 4
  %8 = getelementptr i8, ptr %.tr, i64 24
  %9 = load ptr, ptr %8, align 8
  %10 = load i64, ptr %.tr, align 8
  %11 = add i64 %10, -1
  store i64 %11, ptr %.tr, align 8
  %12 = icmp eq i64 %10, 1
  br i1 %12, label %16, label %13

13:                                               ; preds = %5
  %14 = load i64, ptr %9, align 8
  %15 = add i64 %14, 1
  store i64 %15, ptr %9, align 8
  br label %16

16:                                               ; preds = %5, %13
  %17 = phi ptr [ null, %13 ], [ %.tr, %5 ]
  %18 = trunc i32 %7 to i8
  %19 = lshr i32 %7, 8
  %20 = trunc i32 %19 to i8
  %21 = lshr i32 %7, 16
  %22 = trunc i32 %21 to i8
  %23 = lshr i32 %7, 24
  %24 = trunc nuw i32 %23 to i8
  %25 = ptrtoint ptr %.tr78 to i64
  %26 = trunc i64 %25 to i8
  %27 = lshr i64 %25, 8
  %28 = trunc i64 %27 to i8
  %29 = lshr i64 %25, 16
  %30 = trunc i64 %29 to i8
  %31 = lshr i64 %25, 24
  %32 = trunc i64 %31 to i8
  %33 = lshr i64 %25, 32
  %34 = trunc i64 %33 to i8
  %35 = lshr i64 %25, 40
  %36 = trunc i64 %35 to i8
  %37 = lshr i64 %25, 48
  %38 = trunc i64 %37 to i8
  %39 = lshr i64 %25, 56
  %40 = trunc nuw i64 %39 to i8
  %.not = icmp eq ptr %17, null
  br i1 %.not, label %41, label %43

41:                                               ; preds = %16
  %42 = tail call align 8 ptr @__reuse_ir_alloc(i64 32, i64 8)
  br label %43

43:                                               ; preds = %41, %16
  %44 = phi ptr [ %42, %41 ], [ %17, %16 ]
  %45 = getelementptr i8, ptr %44, i64 8
  store i64 1, ptr %44, align 8
  store i1 false, ptr %45, align 1
  %.repack40 = getelementptr i8, ptr %44, i64 16
  store i8 %18, ptr %.repack40, align 1
  %.repack40.repack48 = getelementptr i8, ptr %44, i64 17
  store i8 %20, ptr %.repack40.repack48, align 1
  %.repack40.repack50 = getelementptr i8, ptr %44, i64 18
  store i8 %22, ptr %.repack40.repack50, align 1
  %.repack40.repack52 = getelementptr i8, ptr %44, i64 19
  store i8 %24, ptr %.repack40.repack52, align 1
  %.repack40.repack62 = getelementptr i8, ptr %44, i64 24
  store i8 %26, ptr %.repack40.repack62, align 1
  %.repack40.repack64 = getelementptr i8, ptr %44, i64 25
  store i8 %28, ptr %.repack40.repack64, align 1
  %.repack40.repack66 = getelementptr i8, ptr %44, i64 26
  store i8 %30, ptr %.repack40.repack66, align 1
  %.repack40.repack68 = getelementptr i8, ptr %44, i64 27
  store i8 %32, ptr %.repack40.repack68, align 1
  %.repack40.repack70 = getelementptr i8, ptr %44, i64 28
  store i8 %34, ptr %.repack40.repack70, align 1
  %.repack40.repack72 = getelementptr i8, ptr %44, i64 29
  store i8 %36, ptr %.repack40.repack72, align 1
  %.repack40.repack74 = getelementptr i8, ptr %44, i64 30
  store i8 %38, ptr %.repack40.repack74, align 1
  %.repack40.repack76 = getelementptr i8, ptr %44, i64 31
  store i8 %40, ptr %.repack40.repack76, align 1
  br label %tailrecurse

46:                                               ; preds = %tailrecurse
  %47 = load i64, ptr %.tr, align 8
  %48 = add i64 %47, -1
  store i64 %48, ptr %.tr, align 8
  %49 = icmp eq i64 %47, 1
  br i1 %49, label %50, label %51

50:                                               ; preds = %46
  tail call void @__reuse_ir_dealloc(ptr nonnull %.tr, i64 32, i64 8)
  br label %51

51:                                               ; preds = %46, %50
  ret ptr %.tr78
}

declare ptr @__reuse_ir_alloc(i64, i64 allocalign) local_unnamed_addr

declare void @__reuse_ir_dealloc(ptr allocptr, i64, i64 allocalign) local_unnamed_addr

!llvm.module.flags = !{!0}
```
LLVM is repacking the union structure rather than make it a simple load/store. @Lancern I will look into this but could you also check to see if you have some insights?